### PR TITLE
API to retrieve the credentials for non-binding services 

### DIFF
--- a/python_utils.py
+++ b/python_utils.py
@@ -483,8 +483,8 @@ def get_credentials_for_non_binding_service(service):
         result = json.loads(result)
         debug("JSON result: \n" + str(result))
 
-        # return the json as-is, let the caller pull the appropriate data out based on the contents (which may vary
-        # from one service broker to another)
+        # return the json as-is, let the caller pull the appropriate data out (which may vary from one service broker
+        # to another)
         return result
     else:
         LOGGER.error("No service key for service instance %s", service_name)


### PR DESCRIPTION
Normally - credentials are for a service can be acquired from VCAP Services for a bound app.  However not all services are "bindable" or for those that are - you may want to use the service without an app being installed.  For these - services brokers can implement the servce_keys endpoint which allows credentials or API Keys for a service to me retrieved/managed without requiring a bound application.

See the following links for additional background information on the the service_keys endpoint.

https://developer.ibm.com/opentech/2015/07/09/cloudfoundry-services-keys-and-sample-go-service-broker/

http://blog.pivotal.io/pivotal-cloud-foundry/products/new-cloud-foundry-service-broker-updates

Also note that get_credentials_from_bound_app will eventually need to be tweaked in order to leverage the "Setup Service and Space" checkbox in the job configuration for services which are unbindable.
