### PR TITLE
Add RC to retry message

### DIFF
--- a/ice_utils.sh
+++ b/ice_utils.sh
@@ -274,7 +274,7 @@ ice_retry(){
         if [ ${RC} -eq 0 ]; then
             break
         fi
-        echo -e "${label_color}\"${IC_COMMAND} ${iceparms}\" did not return successfully. Sleep 20 sec and try again.${no_color}"
+        echo -e "${label_color}\"${IC_COMMAND} ${iceparms}\" did not return successfully. RC=${RC}. Sleep 20 sec and try again.${no_color}"
         sleep 20
         retries=$(( $retries + 1 ))
     done
@@ -297,7 +297,7 @@ ice_retry_save_output(){
             break
         fi
         debugme cat iceretry.log
-        echo -e "${label_color}\"${IC_COMMAND} ${iceparms}\" did not return successfully. Sleep 20 sec and try again.${no_color}"
+        echo -e "${label_color}\"${IC_COMMAND} ${iceparms}\" did not return successfully. RC=${RC}. Sleep 20 sec and try again.${no_color}"
         sleep 20
         retries=$(( $retries + 1 ))
     done


### PR DESCRIPTION
Adding the RC to the error message, to try and gain an understanding of why the script failed.

This is based on my experience trying to deploy a scaling group and getting a response indicating an error, but no further information on what went wrong. It looks like the logs will automatically be printed to screen from an ice_retry command (they aren't directly captured) and are definitely captured and catted to the screen in an ice_retry_save_output command, so I'm assuming that the zero output I see is because there is actually no output, therefore the only missing information I think is the RC.
