### PR TITLE
Hiding out of date version messages

### DIFF
--- a/ice_utils.sh
+++ b/ice_utils.sh
@@ -266,10 +266,12 @@ ice_build_image() {
     return $RC
 }
 
-###########################################################
-# Ice or (cf ic) command retry function with not output
+#############################################################
+# Ice or (cf ic) command retry function with output to stdout
 # 
-###########################################################
+#       Hides messages about out of date version
+# Pipeline limitations reqiure using an out of date version
+#############################################################
 ice_retry(){
     local RC=0
     local retries=0
@@ -277,8 +279,8 @@ ice_retry(){
     local COMMAND=""
     debugme echo "Command: ${IC_COMMAND} ${iceparms}"
     while [ $retries -lt 5 ]; do
-        $IC_COMMAND $iceparms
-        RC=$?
+        $IC_COMMAND $iceparms | grep -v -f ${EXT_DIR}/utilities/rmVersionMsg.txt
+        RC=${PIPESTATUS[0]}
         if [ ${RC} -eq 0 ]; then
             break
         fi
@@ -292,6 +294,9 @@ ice_retry(){
 ###########################################################
 # Ice or (cf ic) command retry function with save output
 # in iceretry.log file
+#
+#       Hides messages about out of date version
+# Pipeline limitations reqiure using an out of date version
 ###########################################################
 ice_retry_save_output(){
     local RC=0
@@ -299,8 +304,8 @@ ice_retry_save_output(){
     local iceparms="$*"
     debugme echo "Command: ${IC_COMMAND} ${iceparms}"
     while [ $retries -lt 5 ]; do
-        $IC_COMMAND $iceparms > iceretry.log
-        RC=$?
+        $IC_COMMAND $iceparms | grep -v -f ${EXT_DIR}/utilities/rmVersionMsg.txt > iceretry.log
+        RC=${PIPESTATUS[0]}
         if [ ${RC} -eq 0 ]; then
             break
         fi

--- a/rmVersionMsg.txt
+++ b/rmVersionMsg.txt
@@ -1,0 +1,5 @@
+^You are using version .* of the IBM Containers plug-in.
+^Version .* of the plug-in is available for you to install.
+^Run the "cf ic update" command to update your plug-in to the current version.
+^You can review the documentation to see the changes that are included in the new version.
+^https://www.ng.bluemix.net/docs/containers/container_cli_reference_cfic_versions.html


### PR DESCRIPTION
Using simple grep command to hide out of date version messages.  Pipeline limitations require this out of date version of cf ic and the error message causes confusion when other errors are encountered.
