### PR TITLE
Fix to support back-level python requests

### DIFF
--- a/gp_create.py
+++ b/gp_create.py
@@ -124,7 +124,7 @@ headers = {
     "X-Auth-Project-Id": SPACE_GUID
 }
 
-response = requests.post(url, json=data, headers=headers)
+response = requests.post(url, data=json.dumps(data), headers=headers)
 
 if response.status_code > 400:
     python_utils.LOGGER.error("Received %i status code from api server" %(response.status_code))


### PR DESCRIPTION
When testing in the pipeline, the version of python used does not support the json parameter on requests.post.  Using json.dumps for compatibility.
